### PR TITLE
Fix documentation for scrutinizer

### DIFF
--- a/src/FeatureToggler.php
+++ b/src/FeatureToggler.php
@@ -29,7 +29,7 @@ class FeatureToggler
 
     /**
      * @param string $key
-     * @param bool|false $defaultValue
+     * @param bool|string $defaultValue
      * @return array|mixed|null
      */
     public function isEnabled($key, $defaultValue = false)


### PR DESCRIPTION
Scrutinizer is warning about the method documentation. The documentation said that method accept only bool values, however the method accepts strings values.
